### PR TITLE
Standardize API responses

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,8 @@ const readLimiter = rateLimit({
 
 // Cookies and CSRF
 app.use(cookieParser());
+// Standardize API responses
+app.use(require('./libs/utils/response.format.js'));
 app.use((req, res, next) => {
   if (
     req.path.startsWith('/ai-') ||
@@ -123,8 +125,8 @@ app.use((req, res, next) => {
 });
 
 // Endpoint to obtain the CSRF token
-app.get("/csrf-token", (req, res) => {
-  res.status(200).json({ csrfToken: req.csrfToken() });
+app.get('/csrf-token', (req, res) => {
+  res.status(200).json({ data: { csrfToken: req.csrfToken() }, error: null, message: null });
 });
 
 // Authentication (login/logout/token)
@@ -159,8 +161,8 @@ app.use('/ai-rfis', require("./openai/general/rfis.google.ai.js"));
 app.use('/ai-modeldata', require("./openai/general/model.google.ai.js"));
 
 // Health check
-app.get("/", (req, res) => {
-  res.json({ message: "TAD‑APP‑Backend API is alive 🚀" });
+app.get('/', (req, res) => {
+  res.json({ data: null, error: null, message: 'TAD‑APP‑Backend API is alive 🚀' });
 });
 
 // Iniciar servidor (si se ejecuta directamente)
@@ -183,12 +185,13 @@ app.use((err, req, res, next) => {
   if (process.env.NODE_ENV === 'development') {
     console.error(err.stack);
     return res.status(err.status || 500).json({
-      message: err.message,
-      stack: err.stack
+      data: null,
+      error: err.stack,
+      message: err.message
     });
   }
   console.error(err.message);
-  res.status(err.status || 500).json({ message: 'Internal server error' });
+  res.status(err.status || 500).json({ data: null, error: err.message, message: 'Internal server error' });
 });
 
 module.exports = app;

--- a/libs/general/validatetoken.js
+++ b/libs/general/validatetoken.js
@@ -3,7 +3,9 @@ const axios = require("axios");
 const validateAutodeskToken = async (req, res, next) => {
   const token = req.cookies.access_token;
 
-  if (!token) return res.status(401).json({ error: "Unauthorized" });
+  if (!token) {
+    return res.status(401).json({ data: null, error: 'Unauthorized', message: 'Unauthorized' });
+  }
 
   try {
     const { data } = await axios.get(
@@ -14,7 +16,7 @@ const validateAutodeskToken = async (req, res, next) => {
     req.user = data;
     next();
   } catch (err) {
-    res.status(401).json({ error: "Invalid token" });
+    res.status(401).json({ data: null, error: 'Invalid token', message: 'Invalid token' });
   }
 };
 

--- a/libs/utils/response.format.js
+++ b/libs/utils/response.format.js
@@ -1,0 +1,24 @@
+module.exports = (req, res, next) => {
+  const originalJson = res.json.bind(res);
+  res.json = (body) => {
+    let data = null;
+    let error = null;
+    let message = null;
+
+    if (body && typeof body === 'object') {
+      if (Object.prototype.hasOwnProperty.call(body, 'data') &&
+          Object.prototype.hasOwnProperty.call(body, 'error') &&
+          Object.prototype.hasOwnProperty.call(body, 'message')) {
+        return originalJson(body);
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'data')) data = body.data;
+      else data = body;
+      if (Object.prototype.hasOwnProperty.call(body, 'error')) error = body.error;
+      if (Object.prototype.hasOwnProperty.call(body, 'message')) message = body.message;
+    } else if (body !== undefined) {
+      data = body;
+    }
+    return originalJson({ data, error, message });
+  };
+  next();
+};

--- a/openai/general/issues.google.ai.js
+++ b/openai/general/issues.google.ai.js
@@ -14,11 +14,11 @@ router.post("/issues", async (req, res) => {
   let { message, accountId, projectId } = req.body;
 
   if (!message || !accountId || !projectId) {
-    return res.status(400).json({ error: "Missing required fields" });
+    return res.status(400).json({ data: null, error: 'Missing required fields', message: 'Missing required fields' });
   }
 
   if (!process.env.GOOGLE_API_KEY) {
-    return res.status(500).json({ error: "Google API key not set" });
+    return res.status(500).json({ data: null, error: 'Google API key not set', message: 'Google API key not set' });
   }
 
   try {
@@ -61,7 +61,7 @@ router.post("/issues", async (req, res) => {
     console.debug("In Review Issues:", inreviewIssues);
 
     if (totalIssues === 0) {
-      return res.json({ reply: "I found no issues data for this project." });
+      return res.json({ data: { reply: 'I found no issues data for this project.' }, error: null, message: null });
     }
 
     const formattedIssuesData = issues
@@ -178,21 +178,19 @@ Please respond clearly in English and concisely to the following question: ${mes
       }
     }
 
-    const reply = response.candidates[0].content.parts[0].text.trim(); 
+    const reply = response.candidates[0].content.parts[0].text.trim();
 
-    res.json({ reply });
+    res.json({ data: { reply }, error: null, message: null });
   } catch (error) {
-    console.error("Error processing /ai/issues request:", error); 
+    console.error("Error processing /ai/issues request:", error);
     if (error.message.includes("collection")) {
       res
         .status(500)
-        .json({ error: "Database error while processing issues." });
+        .json({ data: null, error: 'Database error while processing issues.', message: 'Database error' });
     } else {
       res
         .status(500)
-        .json({
-          error: "Internal server error processing the issues request.",
-        });
+        .json({ data: null, error: 'Internal server error processing the issues request.', message: 'Internal server error' });
     }
   }
 });

--- a/openai/general/model.google.ai.js
+++ b/openai/general/model.google.ai.js
@@ -23,10 +23,10 @@ async function handleAIRequest(req, res, mode) {
   const { message, accountId, projectId, contextData } = req.body;
 
   if (!message || !accountId || !projectId) {
-    return res.status(400).json({ error: "Missing required fields" });
+    return res.status(400).json({ data: null, error: 'Missing required fields', message: 'Missing required fields' });
   }
   if (!process.env.GOOGLE_API_KEY) {
-    return res.status(500).json({ error: "Google API key not set" });
+    return res.status(500).json({ data: null, error: 'Google API key not set', message: 'Google API key not set' });
   }
 
    try {
@@ -77,10 +77,10 @@ Question: ${message}`;
     let payload;
     try { payload = JSON.parse(reply); } catch(e) { payload = null; }
 
-    res.json({ reply, ...(payload || {}) });
+    res.json({ data: { reply, ...(payload || {}) }, error: null, message: null });
   } catch (err) {
     console.error("Error in AI modeldata:", err);
-    res.status(500).json({ error: err.message });
+    res.status(500).json({ data: null, error: err.message, message: 'Internal server error' });
   }
 }
 

--- a/openai/general/rfis.google.ai.js
+++ b/openai/general/rfis.google.ai.js
@@ -10,10 +10,10 @@ const router = express.Router();
 router.post("/rfis", async (req, res) => {
   const { message, accountId, projectId } = req.body;
   if (!message || !accountId || !projectId) {
-    return res.status(400).json({ error: "Missing required fields" });
+    return res.status(400).json({ data: null, error: 'Missing required fields', message: 'Missing required fields' });
   }
   if (!process.env.GOOGLE_API_KEY) {
-    return res.status(500).json({ error: "Google API key not set" });
+    return res.status(500).json({ data: null, error: 'Google API key not set', message: 'Google API key not set' });
   }
 
   try {
@@ -78,10 +78,10 @@ QUESTION: ${message}
         generationConfig: { temperature: 0.2 },
       });
     const reply = (await result.response).text().trim();
-    res.json({ reply });
+    res.json({ data: { reply }, error: null, message: null });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ data: null, error: 'Internal server error', message: 'Internal server error' });
   }
 });
 

--- a/openai/general/submittals.google.ai.js
+++ b/openai/general/submittals.google.ai.js
@@ -10,10 +10,10 @@ const router = express.Router();
 router.post("/submittals", async (req, res) => {
   const { message, accountId, projectId } = req.body;
   if (!message || !accountId || !projectId) {
-    return res.status(400).json({ error: "Missing required fields" });
+    return res.status(400).json({ data: null, error: 'Missing required fields', message: 'Missing required fields' });
   }
   if (!process.env.GOOGLE_API_KEY) {
-    return res.status(500).json({ error: "Google API key not set" });
+    return res.status(500).json({ data: null, error: 'Google API key not set', message: 'Google API key not set' });
   }
 
   try {
@@ -72,10 +72,10 @@ QUESTION: ${message}
         generationConfig: { temperature: 0.2 },
       });
     const reply = (await result.response).text().trim();
-    res.json({ reply });
+    res.json({ data: { reply }, error: null, message: null });
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ data: null, error: 'Internal server error', message: 'Internal server error' });
   }
 });
 

--- a/openai/general/users.google.ai.js
+++ b/openai/general/users.google.ai.js
@@ -12,11 +12,11 @@ router.post("/users", async (req, res) => {
   let { message, accountId, projectId } = req.body;
 
   if (!message || !accountId || !projectId) {
-    return res.status(400).json({ error: "Missing required fields" });
+    return res.status(400).json({ data: null, error: 'Missing required fields', message: 'Missing required fields' });
   }
 
   if (!process.env.GOOGLE_API_KEY) {
-    return res.status(500).json({ error: "Google API key not set" });
+    return res.status(500).json({ data: null, error: 'Google API key not set', message: 'Google API key not set' });
   }
 
   try {
@@ -54,7 +54,7 @@ router.post("/users", async (req, res) => {
     ).length;
 
     if (!users || users.length === 0) {
-      return res.status(404).json({ error: "No users found" });
+      return res.status(404).json({ data: null, error: 'No users found', message: 'No users found' });
     }
 
     const usersData = users
@@ -135,14 +135,16 @@ router.post("/users", async (req, res) => {
         response?.promptFeedback?.safetyRatings || {}
       );
       return res.status(500).json({
+        data: null,
         error: `No response from Google AI. Reason: ${reason}. Safety Ratings: ${safetyRatings}`,
+        message: 'AI response empty'
       });
     }
 
-    res.json({ reply });
+    res.json({ data: { reply }, error: null, message: null });
   } catch (error) {
     console.error("Error processing request:", error);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(500).json({ data: null, error: 'Internal server error', message: 'Internal server error' });
   }
 });
 

--- a/resources/auth/auth.user.status.controller.js
+++ b/resources/auth/auth.user.status.controller.js
@@ -6,7 +6,7 @@ const GetUserStatus = async (req, res) => {
   const token = req.cookies["access_token"];
 
   if (!token) {
-    return res.status(401).json({ authenticated: false });
+    return res.status(401).json({ data: { authenticated: false }, error: null, message: 'Unauthorized' });
   }
 
   try {
@@ -21,13 +21,13 @@ const GetUserStatus = async (req, res) => {
     );
 
     if (userData?.userId) {
-      return res.status(200).json({ authenticated: true });
+      return res.status(200).json({ data: { authenticated: true }, error: null, message: null });
     }
 
-    return res.status(401).json({ authenticated: false });
+    return res.status(401).json({ data: { authenticated: false }, error: null, message: 'Unauthorized' });
   } catch (error) {
     console.error("🔐 Error validating Autodesk token:", error.message);
-    return res.status(401).json({ authenticated: false });
+    return res.status(401).json({ data: { authenticated: false }, error: null, message: 'Invalid token' });
   }
 };
 

--- a/resources/datamanagement/datamanagement.folder.permits.js
+++ b/resources/datamanagement/datamanagement.folder.permits.js
@@ -13,7 +13,9 @@ const {
 async function GetFolderPermits(req, res) {
   const token = req.cookies["access_token"];
   const { accountId, projectId } = req.params;
-  if (!token) return res.status(401).json({ error: "Unauthorized" });
+  if (!token) {
+    return res.status(401).json({ data: null, error: 'Unauthorized', message: 'Unauthorized' });
+  }
 
   try {
     const folders = await GetAllProjectFolders(token, accountId, projectId);
@@ -107,7 +109,7 @@ async function GetFolderPermits(req, res) {
     });
   } catch (err) {
     console.error("GetFolderPermits:", err);
-    return res.status(500).json({ error: err.message });
+    return res.status(500).json({ data: null, error: err.message, message: 'Internal server error' });
   }
 }
 

--- a/resources/task/task.controller.js
+++ b/resources/task/task.controller.js
@@ -79,9 +79,9 @@ const createTask = async (req, res) => {
     console.error("Error creating tasks:", error);
     if (error.name === "ValidationError") {
       const messages = Object.values(error.errors).map(v => v.message);
-      return res.status(400).json({ error: messages.join(" ") });
+      return res.status(400).json({ data: null, error: messages.join(' '), message: messages.join(' ') });
     }
-      return res.status(500).json({ message: "Server error while creating tasks." });
+      return res.status(500).json({ data: null, error: 'Server error while creating tasks.', message: 'Server error while creating tasks.' });
   }
 };
 
@@ -97,7 +97,7 @@ const getAllTasks = async (req, res) => {
       return res.json({ data: tasks, error: null, message: "Tasks retrieved successfully." });
   } catch (error) {
     console.error("Error fetching tasks:", error);
-      return res.status(500).json({ message: "Server error while fetching tasks." });
+      return res.status(500).json({ data: null, error: 'Server error while fetching tasks.', message: 'Server error while fetching tasks.' });
   }
 };
 
@@ -132,9 +132,9 @@ const updateTask = async (req, res) => {
     console.error("Error updating task:", error);
     if (error.name === "ValidationError") {
       const msgs = Object.values(error.errors).map(v => v.message);
-      return res.status(400).json({ error: msgs.join(" ") });
+      return res.status(400).json({ data: null, error: msgs.join(' '), message: msgs.join(' ') });
     }
-      return res.status(500).json({ message: "Server error while updating the task." });
+      return res.status(500).json({ data: null, error: 'Server error while updating the task.', message: 'Server error while updating the task.' });
   }
 };
 
@@ -153,7 +153,7 @@ const deleteTask = async (req, res) => {
       return res.status(404).json({ data: null, error: "Not Found", message: "Task not found." });
   } catch (error) {
     console.error("Error deleting task:", error);
-    return res.status(500).json({ message: "Server error while deleting the task." });
+    return res.status(500).json({ data: null, error: 'Server error while deleting the task.', message: 'Server error while deleting the task.' });
   }
 };
 


### PR DESCRIPTION
## Summary
- add middleware to enforce `{data,error,message}` structure
- use middleware in server
- update CSRF and root health routes
- return structured errors in validation middleware and controllers
- adjust Gemini AI routes to send structured responses

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac5d2c308323836a1dbe9f43f9ed