### PR TITLE
Centralize environment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ORDS_SCHEMA=admin              # optional
 MONGODB_DATABASE_URL=mongodb://localhost:27017/tad
 
 GOOGLE_API_KEY=<Google generative AI API key>
+AUTODESK_BASE_URL=https://developer.api.autodesk.com
 NODE_ENV=development           # production or development
 ```
 

--- a/app.js
+++ b/app.js
@@ -1,18 +1,16 @@
+const env = require('./config/env.js');
 const express = require("express");
 const rateLimit = require('express-rate-limit');
 const morgan = require("morgan");
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const helmet = require("helmet");
-const dotenv = require("dotenv");
-const csurf = require("csurf");
 
-dotenv.config();
 require('./config/mongodb.js');
 
-const PORT = process.env.PORT || 3000;
+const PORT = env.PORT;
 const allowedOrigins = [
-  process.env.FRONTEND_URL,
+  env.FRONTEND_URL,
   "http://localhost:5173",
   "https://tad-app-fronend.vercel.app",
 ];
@@ -69,7 +67,7 @@ app.use(
       ],
       connectSrc: [
         "'self'",
-        "https://developer.api.autodesk.com",
+        env.AUTODESK_BASE_URL,
         "https://cdn.derivative.autodesk.com",
         "https://tad-app-backend.vercel.app",
         "https://tad-app-fronend.vercel.app",
@@ -116,7 +114,7 @@ app.use((req, res, next) => {
   return csurf({
     cookie: {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: env.NODE_ENV === 'production',
       sameSite: 'Lax',
     },
   })(req, res, next);
@@ -180,7 +178,7 @@ app.use((err, req, res, next) => {
 
 // Global error handling
 app.use((err, req, res, next) => {
-  if (process.env.NODE_ENV === 'development') {
+  if (env.NODE_ENV === 'development') {
     console.error(err.stack);
     return res.status(err.status || 500).json({
       message: err.message,

--- a/config/database.helper.js
+++ b/config/database.helper.js
@@ -1,8 +1,9 @@
+const env = require('./env.js');
 // config/database.helper.js
 
 const axios = require("axios");
-const ORDS_URL = process.env.ORDS_URL;
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+const ORDS_URL = env.ORDS_URL;
+const ADMIN_PASSWORD = env.ADMIN_PASSWORD;
 if (!ORDS_URL || !ADMIN_PASSWORD) {
   console.error("❌ Define ORDS_URL (without /admin) and ADMIN_PASSWORD");
   process.exit(1);

--- a/config/database.js
+++ b/config/database.js
@@ -1,7 +1,8 @@
+const env = require('./env.js');
 const axios = require("axios");
 
-const ORDS_URL = process.env.ORDS_URL;
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+const ORDS_URL = env.ORDS_URL;
+const ADMIN_PASSWORD = env.ADMIN_PASSWORD;
 if (!ORDS_URL || !ADMIN_PASSWORD) {
   console.error("❌ Define ORDS_URL (sin /admin) y ADMIN_PASSWORD");
   process.exit(1);

--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,19 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+const env = {
+  PORT: process.env.PORT || 3000,
+  FRONTEND_URL: process.env.FRONTEND_URL || 'http://localhost:5173',
+  APS_CLIENT_ID: process.env.APS_CLIENT_ID,
+  APS_CLIENT_SECRET: process.env.APS_CLIENT_SECRET,
+  REDIRECT_URI: process.env.REDIRECT_URI || 'http://localhost:3000/auth/three-legged',
+  ORDS_URL: process.env.ORDS_URL,
+  ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
+  ORDS_SCHEMA: process.env.ORDS_SCHEMA || 'admin',
+  MONGODB_DATABASE_URL: process.env.MONGODB_DATABASE_URL,
+  GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  NODE_ENV: process.env.NODE_ENV || 'development',
+  AUTODESK_BASE_URL: process.env.AUTODESK_BASE_URL || 'https://developer.api.autodesk.com'
+};
+
+module.exports = env;

--- a/config/mongodb.js
+++ b/config/mongodb.js
@@ -1,6 +1,7 @@
+const env = require('./env.js');
 const mongoose = require('mongoose');
 
-const url = process.env.MONGODB_DATABASE_URL;
+const url = env.MONGODB_DATABASE_URL;
 if (!url) {
   console.error('❌ Define MONGODB_DATABASE_URL');
   process.exit(1);

--- a/libs/acc/acc.libs.js
+++ b/libs/acc/acc.libs.js
@@ -1,3 +1,4 @@
+const env = require("../config/env.js");
 const express = require("express");
 const axios = require("axios");
 const router = express.Router();
@@ -6,7 +7,7 @@ const { format } = require("morgan");
 const { fetchAllPaginatedResults } = require("../utils/pagination.libs");
 
 const GetUserbyUserId = async (userId, projectId, token) => {
-  const url = `https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users/${userId}`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users/${userId}`;
 
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -31,7 +32,7 @@ const GetUserbyUserId = async (userId, projectId, token) => {
 };
 
 const GetIssueTypeName = async (projectId, token) => {
-  const url = `https://developer.api.autodesk.com/construction/issues/v1/projects/${projectId}/issue-types`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/issues/v1/projects/${projectId}/issue-types`;
 
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -52,7 +53,7 @@ const GetIssueTypeName = async (projectId, token) => {
 };
 
 const GetIssueAttributeDefinitions = async (projectId, token) => {
-  const url = `https://developer.api.autodesk.com/construction/issues/v1/projects/${projectId}/issue-attribute-definitions`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/issues/v1/projects/${projectId}/issue-attribute-definitions`;
 
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -74,7 +75,7 @@ const GetIssueAttributeDefinitions = async (projectId, token) => {
 };
 
 const GetSubmittalSpecId = async (projectId, specId, token) => {
-  const url = `https://developer.api.autodesk.com/construction/submittals/v2/projects/${projectId}/specs/${specId}`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/submittals/v2/projects/${projectId}/specs/${specId}`;
 
   const headers = {
     Authorization: `Bearer ${token}`,

--- a/libs/bim360/bim360.libs.js
+++ b/libs/bim360/bim360.libs.js
@@ -1,3 +1,4 @@
+const env = require("../config/env.js");
 const express = require("express");
 const axios = require("axios");
 const router = express.Router();
@@ -6,7 +7,7 @@ const { format } = require("morgan");
 const { fetchAllPaginatedResults } = require("../utils/pagination.libs");
 
 const GetUserbyUserId = async (userId, projectId, token) => {
-  const url = `https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users/${userId}`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users/${userId}`;
 
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -31,7 +32,7 @@ const GetUserbyUserId = async (userId, projectId, token) => {
 };
 
 const GetIssueTypeName = async (projectId, token) => {
-  const url = `https://developer.api.autodesk.com/issues/v2/containers/${projectId}/issue-types`;
+  const url = `${env.AUTODESK_BASE_URL}/issues/v2/containers/${projectId}/issue-types`;
 
   const headers = {
     Authorization: `Bearer ${token}`,
@@ -52,7 +53,7 @@ const GetIssueTypeName = async (projectId, token) => {
 };
 
 const GetIssueAttributeDefinitions = async (projectId, token) => {
-  const url = `https://developer.api.autodesk.com/issues/v2/containers/${projectId}/issue-attribute-definitions`;
+  const url = `${env.AUTODESK_BASE_URL}/issues/v2/containers/${projectId}/issue-attribute-definitions`;
 
   const headers = {
     Authorization: `Bearer ${token}`,

--- a/libs/general/auth.libs.js
+++ b/libs/general/auth.libs.js
@@ -1,11 +1,12 @@
+const env = require('../../config/env.js');
 const express = require("express");
 const axios = require("axios");
 const router = express.Router();
 
-const APS_CLIENT_ID = process.env.APS_CLIENT_ID;
-const APS_CLIENT_SECRET = process.env.APS_CLIENT_SECRET;
+const APS_CLIENT_ID = env.APS_CLIENT_ID;
+const APS_CLIENT_SECRET = env.APS_CLIENT_SECRET;
 const redirect_uri =
-  process.env.REDIRECT_URI || "http://localhost:3000/auth/three-legged";
+  env.REDIRECT_URI || "http://localhost:3000/auth/three-legged";
 
 const GetAPSThreeLeggedToken = async (code) => {
   if (!APS_CLIENT_ID || !APS_CLIENT_SECRET) {
@@ -32,7 +33,7 @@ const GetAPSThreeLeggedToken = async (code) => {
 
   try {
     const { data } = await axios.post(
-      "https://developer.api.autodesk.com/authentication/v2/token",
+      `${env.AUTODESK_BASE_URL}/authentication/v2/token`,
       new URLSearchParams(requestdata).toString(),
       { headers }
     );
@@ -66,7 +67,7 @@ const GetAPSToken = async () => {
   };
 
   const { data } = await axios.post(
-    "https://developer.api.autodesk.com/authentication/v2/token",
+    `${env.AUTODESK_BASE_URL}/authentication/v2/token`,
     new URLSearchParams(requestdata).toString(),
     { headers }
   );

--- a/libs/general/folders.libs.js
+++ b/libs/general/folders.libs.js
@@ -1,3 +1,4 @@
+const env = require("../config/env.js");
 const axios = require("axios");
 
 
@@ -8,7 +9,7 @@ const GetFederatedModelFromFolders = async ({
   matchWord,
   filterFn,
 }) => {
-  const url = `https://developer.api.autodesk.com/data/v1/projects/${projectId}/folders/${folderId}/contents`;
+  const url = `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/folders/${folderId}/contents`;
 
   const { data: folderContent } = await axios.get(url, {
     headers: { Authorization: `Bearer ${token}` },

--- a/libs/general/revisions.libs.js
+++ b/libs/general/revisions.libs.js
@@ -1,7 +1,8 @@
+const env = require("../config/env.js");
 const axios = require("axios");
 
 const GetProjectReviews = async (token, projectId) => {
-  const url = `https://developer.api.autodesk.com/construction/reviews/v1/projects/${projectId}/reviews`;
+  const url = `${env.AUTODESK_BASE_URL}/construction/reviews/v1/projects/${projectId}/reviews`;
 
   const headers = {
     Authorization: `Bearer ${token}`,

--- a/libs/general/validatetoken.js
+++ b/libs/general/validatetoken.js
@@ -1,3 +1,4 @@
+const env = require("../config/env.js");
 const axios = require("axios");
 
 const validateAutodeskToken = async (req, res, next) => {
@@ -7,7 +8,7 @@ const validateAutodeskToken = async (req, res, next) => {
 
   try {
     const { data } = await axios.get(
-      "https://developer.api.autodesk.com/userprofile/v1/users/@me",
+      "${env.AUTODESK_BASE_URL}/userprofile/v1/users/@me",
       { headers: { Authorization: `Bearer ${token}` } }
     );
 

--- a/libs/utils/folders.content.js
+++ b/libs/utils/folders.content.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const express =  require ('express');
 
 const axios = require('axios');
@@ -16,7 +17,7 @@ const  GetFolderContent = async (token, projectId, folderId) => {
 
     try {
         const { data: folderContent } = await axios.get(
-            `https://developer.api.autodesk.com/data/v1/projects/${projectId}/folders/${folderId}/contents`,
+            `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/folders/${folderId}/contents`,
             {
                 headers: {
                     Authorization: `Bearer ${token}`,
@@ -66,7 +67,7 @@ const  GetFolderContent = async (token, projectId, folderId) => {
 
 const GetFileVersions = async (token, projectId, fileId) => {
     try {
-        const { data } = await axios.get(`https://developer.api.autodesk.com/data/v1/projects/${projectId}/items/${fileId}/versions`, {
+        const { data } = await axios.get(`${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/items/${fileId}/versions`, {
             headers: {
                 Authorization: `Bearer ${token}`
             }

--- a/openai/general/issues.google.ai.js
+++ b/openai/general/issues.google.ai.js
@@ -1,3 +1,4 @@
+const env = require('../../config/env.js');
 const express = require("express");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const getDb  = require("../../config/mongodb.js");
@@ -6,7 +7,7 @@ const issuesSchema = require("../../resources/schemas/issues.schema.js");
 
 const { sanitize } = require("../../libs/utils/sanitaze.db.js");
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const genAI = new GoogleGenerativeAI(env.GOOGLE_API_KEY);
 
 const router = express.Router();
 
@@ -17,7 +18,7 @@ router.post("/issues", async (req, res) => {
     return res.status(400).json({ error: "Missing required fields" });
   }
 
-  if (!process.env.GOOGLE_API_KEY) {
+  if (!env.GOOGLE_API_KEY) {
     return res.status(500).json({ error: "Google API key not set" });
   }
 

--- a/openai/general/model.google.ai.js
+++ b/openai/general/model.google.ai.js
@@ -1,3 +1,4 @@
+const env = require('../../config/env.js');
 
 const express = require('express');
 const {GoogleGenerativeAI} = require('@google/generative-ai');
@@ -5,7 +6,7 @@ const getDb  = require("../../config/mongodb.js");
 const modeldatabaseSchema = require('../../resources/schemas/model.schema.js');
 const {sanitize} = require('../../libs/utils/sanitaze.db.js');
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const genAI = new GoogleGenerativeAI(env.GOOGLE_API_KEY);
 const router = express.Router();
 
 async function buildModelDataContext(accountId, projectId) {
@@ -25,7 +26,7 @@ async function handleAIRequest(req, res, mode) {
   if (!message || !accountId || !projectId) {
     return res.status(400).json({ error: "Missing required fields" });
   }
-  if (!process.env.GOOGLE_API_KEY) {
+  if (!env.GOOGLE_API_KEY) {
     return res.status(500).json({ error: "Google API key not set" });
   }
 

--- a/openai/general/rfis.google.ai.js
+++ b/openai/general/rfis.google.ai.js
@@ -1,10 +1,11 @@
+const env = require('../../config/env.js');
 const express = require("express");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const  getDb  = require("../../config/mongodb.js");
 const rfiSchema = require("../../resources/schemas/rfis.schema.js");
 const { sanitize } = require("../../libs/utils/sanitaze.db.js");
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const genAI = new GoogleGenerativeAI(env.GOOGLE_API_KEY);
 const router = express.Router();
 
 router.post("/rfis", async (req, res) => {
@@ -12,7 +13,7 @@ router.post("/rfis", async (req, res) => {
   if (!message || !accountId || !projectId) {
     return res.status(400).json({ error: "Missing required fields" });
   }
-  if (!process.env.GOOGLE_API_KEY) {
+  if (!env.GOOGLE_API_KEY) {
     return res.status(500).json({ error: "Google API key not set" });
   }
 

--- a/openai/general/submittals.google.ai.js
+++ b/openai/general/submittals.google.ai.js
@@ -1,10 +1,11 @@
+const env = require('../../config/env.js');
 const express = require("express");
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const  getDb  = require("../../config/mongodb.js");
 const submittalsSchema = require("../../resources/schemas/submittals.schema.js");
 const { sanitize } = require("../../libs/utils/sanitaze.db.js");
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const genAI = new GoogleGenerativeAI(env.GOOGLE_API_KEY);
 const router = express.Router();
 
 router.post("/submittals", async (req, res) => {
@@ -12,7 +13,7 @@ router.post("/submittals", async (req, res) => {
   if (!message || !accountId || !projectId) {
     return res.status(400).json({ error: "Missing required fields" });
   }
-  if (!process.env.GOOGLE_API_KEY) {
+  if (!env.GOOGLE_API_KEY) {
     return res.status(500).json({ error: "Google API key not set" });
   }
 

--- a/openai/general/users.google.ai.js
+++ b/openai/general/users.google.ai.js
@@ -1,3 +1,4 @@
+const env = require('../../config/env.js');
 const express = require("express");
 
 const { GoogleGenerativeAI } = require("@google/generative-ai");
@@ -5,7 +6,7 @@ const getDb  = require("../../config/mongodb.js");
 const projectUsersSchema = require("../../resources/schemas/project.users.schema.js");
 const { sanitize } = require("../../libs/utils/sanitaze.db.js");
 
-const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY);
+const genAI = new GoogleGenerativeAI(env.GOOGLE_API_KEY);
 const router = express.Router();
 
 router.post("/users", async (req, res) => {
@@ -15,7 +16,7 @@ router.post("/users", async (req, res) => {
     return res.status(400).json({ error: "Missing required fields" });
   }
 
-  if (!process.env.GOOGLE_API_KEY) {
+  if (!env.GOOGLE_API_KEY) {
     return res.status(500).json({ error: "Google API key not set" });
   }
 

--- a/resources/acc/account_admin/acc.account.admin.controller.js
+++ b/resources/acc/account_admin/acc.account.admin.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 const { authorizedHubs } = require("../../../const/target.hubs.js");
@@ -17,7 +18,7 @@ const GetProjects = async (req, res) => {
     //console.log('Token:', token);
 
     const { data: hubsdata } = await axios.get(
-      "https://developer.api.autodesk.com/project/v1/hubs",
+      "${env.AUTODESK_BASE_URL}/project/v1/hubs",
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -44,7 +45,7 @@ const GetProjects = async (req, res) => {
     const projectsPromises = targetHubs.map((hub) => {
       return axios
         .get(
-          `https://developer.api.autodesk.com/project/v1/hubs/${hub.id}/projects`,
+          `${env.AUTODESK_BASE_URL}/project/v1/hubs/${hub.id}/projects`,
           {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/resources/acc/account_admin/acc.project.controller.js
+++ b/resources/acc/account_admin/acc.project.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 const { authorizedHubs } = require("../../../const/target.hubs.js");
@@ -17,7 +18,7 @@ const GetProject = async (req, res) => {
 
   try {
     const { data: projectdata } = await axios.get(
-      `https://developer.api.autodesk.com/project/v1/hubs/${accountId}/projects/${projectId}`,
+      `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/resources/acc/account_admin/acc.project.users.controller.js
+++ b/resources/acc/account_admin/acc.project.users.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -25,7 +26,7 @@ const GetProjectUsers = async (req, res) => {
 
   try {
     let allProjectUsers = [];
-    let nextUrl = `	https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
+    let nextUrl = `	${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
 
     while (nextUrl) {
       const { data: users } = await axios.get(nextUrl, {

--- a/resources/acc/issues/acc.controller.issues.js
+++ b/resources/acc/issues/acc.controller.issues.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -40,7 +41,7 @@ const GetIssues = async (req, res) => {
 
   try {
     const issues = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/construction/issues/v1/projects/${projectId}/issues`,
+      `${env.AUTODESK_BASE_URL}/construction/issues/v1/projects/${projectId}/issues`,
       token
     );
 

--- a/resources/acc/rfis/acc.controller.rfis.js
+++ b/resources/acc/rfis/acc.controller.rfis.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -32,7 +33,7 @@ const GetRfis = async (req, res) => {
 
   try {
     const rfis = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/bim360/rfis/v2/containers/${projectId}/rfis`,
+      `${env.AUTODESK_BASE_URL}/bim360/rfis/v2/containers/${projectId}/rfis`,
       token
     );
 

--- a/resources/acc/submittals/acc.controller.submittals.js
+++ b/resources/acc/submittals/acc.controller.submittals.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -42,7 +43,7 @@ const GetSubmittals = async (req, res) => {
 
   try {
     const submittals = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/construction/submittals/v2/projects/${projectId}/items`,
+      `${env.AUTODESK_BASE_URL}/construction/submittals/v2/projects/${projectId}/items`,
       token
     );
 

--- a/resources/auth/auth.controller.js
+++ b/resources/auth/auth.controller.js
@@ -1,3 +1,4 @@
+const env = require('../../config/env.js');
 const axios = require("axios");
 const approvedemails = require("../../const/approvedemails");
 const {
@@ -6,7 +7,7 @@ const {
 } = require("../../libs/general/auth.libs");
 
 const fronend_url =
-  process.env.FRONTEND_URL || "http://localhost:5173";
+  env.FRONTEND_URL || "http://localhost:5173";
 
   const GetThreeLegged = async (req, res) => {
     const { code } = req.query;
@@ -14,7 +15,7 @@ const fronend_url =
     try {
       const token = await GetAPSThreeLeggedToken(code);
       const { data: userData } = await axios.get(
-        "https://developer.api.autodesk.com/userprofile/v1/users/@me",
+        "${env.AUTODESK_BASE_URL}/userprofile/v1/users/@me",
         { headers: { Authorization: `Bearer ${token}` } }
       );
       const userEmail = userData.emailId;

--- a/resources/auth/auth.user.status.controller.js
+++ b/resources/auth/auth.user.status.controller.js
@@ -1,6 +1,7 @@
+const env = require('../../config/env.js');
 const axios = require("axios");
 
-const fronend_url = process.env.FRONTEND_URL || "http://localhost:5173";
+const fronend_url = env.FRONTEND_URL || "http://localhost:5173";
 
 const GetUserStatus = async (req, res) => {
   const token = req.cookies["access_token"];
@@ -12,7 +13,7 @@ const GetUserStatus = async (req, res) => {
   try {
  
     const { data: userData } = await axios.get(
-      "https://developer.api.autodesk.com/userprofile/v1/users/@me",
+      "${env.AUTODESK_BASE_URL}/userprofile/v1/users/@me",
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/resources/backs/acc.controller.issues.back.js
+++ b/resources/backs/acc.controller.issues.back.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -41,7 +42,7 @@ const GetIssues = async (req, res) => {
 
   try {
     const issues = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/construction/issues/v1/projects/${projectId}/issues`,
+      `${env.AUTODESK_BASE_URL}/construction/issues/v1/projects/${projectId}/issues`,
       token
     );
 

--- a/resources/backs/acc.controller.submittals.back.js
+++ b/resources/backs/acc.controller.submittals.back.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -40,7 +41,7 @@ const GetSubmittals = async (req, res) => {
 
   try {
     const submittals = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/construction/submittals/v2/projects/${projectId}/items`,
+      `${env.AUTODESK_BASE_URL}/construction/submittals/v2/projects/${projectId}/items`,
       token
     );
 

--- a/resources/backs/acc.project.users.controller.back.js
+++ b/resources/backs/acc.project.users.controller.back.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -25,7 +26,7 @@ const GetProjectUsers = async (req, res) => {
 
   try {
     let allProjectUsers = [];
-    let nextUrl = `	https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
+    let nextUrl = `	${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
 
     while (nextUrl) {
       const { data: users } = await axios.get(nextUrl, {

--- a/resources/backs/acc.rfis.controller.back.js
+++ b/resources/backs/acc.rfis.controller.back.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 const { insertDocs, upsertDoc } = require("../../config/database.js");
@@ -29,7 +30,7 @@ const GetRfis = async (req, res) => {
 
   try {
     const rfis = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/bim360/rfis/v2/containers/${projectId}/rfis`,
+      `${env.AUTODESK_BASE_URL}/bim360/rfis/v2/containers/${projectId}/rfis`,
       token
     );
 

--- a/resources/backs/bim360.controller.issues.back.js
+++ b/resources/backs/bim360.controller.issues.back.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -40,7 +41,7 @@ const GetIssues = async (req, res) => {
 
   try {
     const issues = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/issues/v2/containers/${projectId}/issues`,
+      `${env.AUTODESK_BASE_URL}/issues/v2/containers/${projectId}/issues`,
       token
     );
 

--- a/resources/backs/bim360.controller.rfis.back.js
+++ b/resources/backs/bim360.controller.rfis.back.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -32,7 +33,7 @@ const GetRfis = async (req, res) => {
 
   try {
     const rfis = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/bim360/rfis/v2/containers/${projectId}/rfis`,
+      `${env.AUTODESK_BASE_URL}/bim360/rfis/v2/containers/${projectId}/rfis`,
       token
     );
 

--- a/resources/backs/bim360.project.users.controller.back.js
+++ b/resources/backs/bim360.project.users.controller.back.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -25,7 +26,7 @@ const GetProjectUsers = async (req, res) => {
 
   try {
     let allProjectUsers = [];
-    let nextUrl = `	https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
+    let nextUrl = `	${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
 
     while (nextUrl) {
       const { data: users } = await axios.get(nextUrl, {

--- a/resources/backs/model.controller.back.js
+++ b/resources/backs/model.controller.back.js
@@ -1,3 +1,4 @@
+const env = require('../../config/env.js');
 const { default: axios } = require("axios");
 
 const { format } = require("morgan");
@@ -5,8 +6,8 @@ const { format } = require("morgan");
 const { insertDocs, upsertDoc, getDocs} = require("../../config/database");
 
 const { validateModelData } = require("../../config/database.schema");
-const ORDS_URL = process.env.ORDS_URL;
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+const ORDS_URL = env.ORDS_URL;
+const ADMIN_PASSWORD = env.ADMIN_PASSWORD;
 const basicAuth = Buffer.from(`ADMIN:${ADMIN_PASSWORD}`).toString("base64");
 
 const client = axios.create({
@@ -18,7 +19,7 @@ const client = axios.create({
   timeout: 5000,
 });
 
-const SCHEMA = process.env.ORDS_SCHEMA || 'admin';
+const SCHEMA = env.ORDS_SCHEMA || 'admin';
 
 function getCollName(accountId, projectId) {
   return `${accountId}_${projectId}_modeldatabase`;

--- a/resources/bim360/account_admin/bim360.account.admin.controller.js
+++ b/resources/bim360/account_admin/bim360.account.admin.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 const { authorizedHubs } = require("../../../const/target.hubs.js");
@@ -17,7 +18,7 @@ const GetProjects = async (req, res) => {
     //console.log('Token:', token);
 
     const { data: hubsdata } = await axios.get(
-      "https://developer.api.autodesk.com/project/v1/hubs",
+      "${env.AUTODESK_BASE_URL}/project/v1/hubs",
       {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -44,7 +45,7 @@ const GetProjects = async (req, res) => {
     const projectsPromises = targetHubs.map((hub) => {
       return axios
         .get(
-          `https://developer.api.autodesk.com/project/v1/hubs/${hub.id}/projects`,
+          `${env.AUTODESK_BASE_URL}/project/v1/hubs/${hub.id}/projects`,
           {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/resources/bim360/account_admin/bim360.project.controller.js
+++ b/resources/bim360/account_admin/bim360.project.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 const { authorizedHubs } = require("../../../const/target.hubs.js");
@@ -17,7 +18,7 @@ const GetProject = async (req, res) => {
 
   try {
     const { data: projectdata } = await axios.get(
-      `https://developer.api.autodesk.com/project/v1/hubs/${accountId}/projects/${projectId}`,
+      `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/resources/bim360/account_admin/bim360.project.users.controller.js
+++ b/resources/bim360/account_admin/bim360.project.users.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -25,7 +26,7 @@ const GetProjectUsers = async (req, res) => {
 
   try {
     let allProjectUsers = [];
-    let nextUrl = `	https://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
+    let nextUrl = `	${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
 
     while (nextUrl) {
       const { data: users } = await axios.get(nextUrl, {

--- a/resources/bim360/issues/bim360.controller.issues.js
+++ b/resources/bim360/issues/bim360.controller.issues.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -40,7 +41,7 @@ const GetIssues = async (req, res) => {
 
   try {
     const issues = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/issues/v2/containers/${projectId}/issues`,
+      `${env.AUTODESK_BASE_URL}/issues/v2/containers/${projectId}/issues`,
       token
     );
 

--- a/resources/bim360/rfis/bim360.controller.rfis.js
+++ b/resources/bim360/rfis/bim360.controller.rfis.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -32,7 +33,7 @@ const GetRfis = async (req, res) => {
 
   try {
     const rfis = await fetchAllPaginatedResults(
-      `https://developer.api.autodesk.com/bim360/rfis/v2/containers/${projectId}/rfis`,
+      `${env.AUTODESK_BASE_URL}/bim360/rfis/v2/containers/${projectId}/rfis`,
       token
     );
 

--- a/resources/datamanagement/datamanagement.controller.js
+++ b/resources/datamanagement/datamanagement.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const axios = require("axios");
 const {
   GetFederatedModelFromFolders,
@@ -27,7 +28,7 @@ const GetFederatedModel = async (req, res) => {
 
   try {
     const { data: topFolders } = await axios.get(
-      `https://developer.api.autodesk.com/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
+      `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
       { headers: { Authorization: `Bearer ${token}` } }
     );
 
@@ -70,7 +71,7 @@ const GetFederatedModel = async (req, res) => {
     //console.log("Found file:", foundFile);
 
     const { data: versions } = await axios.get(
-      `https://developer.api.autodesk.com/data/v1/projects/${projectId}/items/${foundFile.id}/versions`,
+      `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/items/${foundFile.id}/versions`,
       { headers: { Authorization: `Bearer ${token}` } }
     );
 

--- a/resources/datamanagement/datamanagement.files.reviews.controller.js
+++ b/resources/datamanagement/datamanagement.files.reviews.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const axios = require("axios");
 const { GetProjectReviews } = require("../../libs/general/revisions.libs.js");
 
@@ -33,7 +34,7 @@ const GetFileRevisionStatus = async (req, res) => {
     const merged = await Promise.all(
       itemIds.map(async (itemId) => {
         const url =
-          `https://developer.api.autodesk.com/construction/reviews/v1/projects/${projectId}` +
+          `${env.AUTODESK_BASE_URL}/construction/reviews/v1/projects/${projectId}` +
           `/versions/${encodeURIComponent(itemId)}/approval-status`;
 
         const { data: resp } = await axios.get(url, {

--- a/resources/datamanagement/datamanagement.items.controller.js
+++ b/resources/datamanagement/datamanagement.items.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const axios = require("axios");
 
 const GetFileData = async (req, res) =>{
@@ -26,7 +27,7 @@ const GetFileData = async (req, res) =>{
   try {
     const itemsDetails = await Promise.all(
       itemIds.map(async (itemId) => {
-        const url = `https://developer.api.autodesk.com/data/v1/projects/${projectId}/items/${itemId}`;
+        const url = `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/items/${itemId}`;
 
         const res = await axios.get(url, {
           headers: {

--- a/resources/datamanagement/datamanagement.project.folders.controller.js
+++ b/resources/datamanagement/datamanagement.project.folders.controller.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 
 const { format } = require("morgan");
@@ -18,7 +19,7 @@ const GetFoldersStructure = async (req, res) => {
 
   try {
     const topFolders = await axios.get(
-      `https://developer.api.autodesk.com/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
+      `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/resources/general/user.profile.js
+++ b/resources/general/user.profile.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const { default: axios } = require("axios");
 const { format } = require("morgan");
 
@@ -9,7 +10,7 @@ const GetUserProfile = async (req, res) => {
     }
 
     const response = await axios.get(
-      "https://developer.api.autodesk.com/userprofile/v1/users/@me",
+      "${env.AUTODESK_BASE_URL}/userprofile/v1/users/@me",
       {
         headers: {
           Authorization: `Bearer ${token}`,

--- a/utils/account_admin/all.project.folders.utils.js
+++ b/utils/account_admin/all.project.folders.utils.js
@@ -1,8 +1,9 @@
+const env = require("../../config/env.js");
 const axios = require("axios");
 
 async function getRootFolderId(token, accountId, projectId) {
   const { data } = await axios.get(
-    `https://developer.api.autodesk.com/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
+    `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
   const top = data.data || [];
@@ -17,7 +18,7 @@ async function getRootFolderId(token, accountId, projectId) {
 
 async function listFoldersRecursively(token, projectId, folderId) {
   const { data } = await axios.get(
-    `https://developer.api.autodesk.com/data/v1/projects/${projectId}/folders/${folderId}/contents`,
+    `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/folders/${folderId}/contents`,
     { headers: { Authorization: `Bearer ${token}` } }
   );
   const items = data.data || [];

--- a/utils/account_admin/all.project.users.utils.js
+++ b/utils/account_admin/all.project.users.utils.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const axios = require('axios');
 
 const GetAllProjectUsers = async (token, projectId) => {
@@ -11,7 +12,7 @@ const GetAllProjectUsers = async (token, projectId) => {
         }
 
         let allProjectUsers = [];
-        let nextUrl = `\thttps://developer.api.autodesk.com/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
+        let nextUrl = `\t${env.AUTODESK_BASE_URL}/construction/admin/v1/projects/${projectId}/users?limit=20&offset=0`;
 
         while (nextUrl) {
               const { data: users } = await axios.get(nextUrl, {

--- a/utils/account_admin/folder.permissions.utils.js
+++ b/utils/account_admin/folder.permissions.utils.js
@@ -1,3 +1,4 @@
+const env = require("../../config/env.js");
 const axios = require("axios");
 
 /**
@@ -15,7 +16,7 @@ async function GetFolderPermissions(token, projectId, folders) {
   const calls = folders.map((f) =>
     limit(async () => {
       const { data } = await axios.get(
-        `https://developer.api.autodesk.com/bim360/docs/v1/projects/${projectId}/folders/${f.id}/permissions`,
+        `${env.AUTODESK_BASE_URL}/bim360/docs/v1/projects/${projectId}/folders/${f.id}/permissions`,
         {
           headers: {
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- create `config/env.js` to load environment variables
- use new env module across the codebase
- replace hard-coded Autodesk endpoints with `AUTODESK_BASE_URL`
- document new variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac549ac4832383e6930892a84331