### PR TITLE
Add express-validator input checks

### DIFF
--- a/libs/utils/validation.middleware.js
+++ b/libs/utils/validation.middleware.js
@@ -1,0 +1,9 @@
+const { validationResult } = require('express-validator');
+
+module.exports = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "csurf": "^1.10.0",
     "dotenv": "^16.4.7",
+    "express-validator": "^7.0.1",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",

--- a/resources/model/model.router.js
+++ b/resources/model/model.router.js
@@ -1,15 +1,35 @@
-const express = require("express");
+const express = require('express');
+const { body } = require('express-validator');
 
 const {
   postDataModel,
   getDataModel,
   patchDataModel,
-} = require("../model/model.controller.js");
+} = require('../model/model.controller.js');
+const validate = require('../../libs/utils/validation.middleware');
 
 const router = express.Router();
 
-router.post("/:accountId/:projectId/data", postDataModel);
-router.get("/:accountId/:projectId/data", getDataModel);
-router.patch("/:accountId/:projectId/data/:dbId", patchDataModel);
+router.post(
+  '/:accountId/:projectId/data',
+  [
+    body().custom(val => Array.isArray(val) || (val && typeof val === 'object'))
+      .withMessage('Body must be an object or array')
+      .customSanitizer(v => (Array.isArray(v) ? v : [v])),
+    body('*.dbId').notEmpty().withMessage('dbId is required'),
+    validate
+  ],
+  postDataModel
+);
+router.get('/:accountId/:projectId/data', getDataModel);
+router.patch(
+  '/:accountId/:projectId/data/:dbId',
+  [
+    body('field').notEmpty().withMessage('field is required'),
+    body('value').exists().withMessage('value is required'),
+    validate
+  ],
+  patchDataModel
+);
 
 module.exports = router;

--- a/resources/plans/plans.router.js
+++ b/resources/plans/plans.router.js
@@ -1,12 +1,44 @@
-const  express = require("express");
+const express = require('express');
+const { body } = require('express-validator');
 
-const {postDataModel, getDataModel, patchDataModel, deleteDataModel } =require ("../plans/plans.controller.js")
+const { postDataModel, getDataModel, patchDataModel, deleteDataModel } = require('../plans/plans.controller.js');
+const validate = require('../../libs/utils/validation.middleware');
 
 const router = express.Router();
 
-router.post('/:accountId/:projectId/plans', postDataModel)
+router.post(
+  '/:accountId/:projectId/plans',
+  [
+    body().custom(val => Array.isArray(val) || (val && typeof val === 'object'))
+      .withMessage('Body must be an object or array')
+      .customSanitizer(v => (Array.isArray(v) ? v : [v])),
+    body('*.Id').notEmpty().withMessage('Id is required'),
+    body('*.SheetName').optional().isString(),
+    body('*.SheetNumber').optional().isString(),
+    body('*.Discipline').optional().isString(),
+    body('*.Revision').optional().isString(),
+    body('*.LastModifiedDate').optional().isString(),
+    body('*.InFolder').optional().isBoolean(),
+    body('*.InARevisionProcess').optional().isString(),
+    body('*.RevisionStatus').optional().isString(),
+    validate
+  ],
+  postDataModel
+);
 router.get('/:accountId/:projectId/plans', getDataModel);
-router.patch('/:accountId/:projectId/data/:Id', patchDataModel);
-router.delete('/:accountId/:projectId/plans', deleteDataModel);
+router.patch(
+  '/:accountId/:projectId/data/:Id',
+  [
+    body('field').notEmpty().withMessage('field is required'),
+    body('value').exists().withMessage('value is required'),
+    validate
+  ],
+  patchDataModel
+);
+router.delete(
+  '/:accountId/:projectId/plans',
+  [body('ids').isArray({ min: 1 }).withMessage('ids array required'), validate],
+  deleteDataModel
+);
 
 module.exports = router;

--- a/resources/task/task.router.js
+++ b/resources/task/task.router.js
@@ -1,12 +1,43 @@
-const  express = require ('express');
+const express = require('express');
+const { body } = require('express-validator');
 
-const { createTask, getAllTasks, updateTask, deleteTask } = require('./task.controller.js')
+const { createTask, getAllTasks, updateTask, deleteTask } = require('./task.controller.js');
+const validate = require('../../libs/utils/validation.middleware');
 
 const router = express.Router();
 
-router.post('/:accountId/:projectId/tasks', createTask);
+router.post(
+  '/:accountId/:projectId/tasks',
+  [
+    body().custom(value => Array.isArray(value) || (value && typeof value === 'object'))
+      .withMessage('Body must be an object or array')
+      .customSanitizer(value => (Array.isArray(value) ? value : [value])),
+    body('*.id').notEmpty().withMessage('id is required'),
+    body('*.title').optional().isString(),
+    body('*.description').optional().isString(),
+    body('*.status').optional().isString(),
+    body('*.startDate').optional().isISO8601(),
+    body('*.endDate').optional().isISO8601(),
+    body('*.assignedTo').optional().isString(),
+    validate
+  ],
+  createTask
+);
 router.get('/:accountId/:projectId/tasks', getAllTasks);
-router.patch('/:accountId/:projectId/tasks/:id', updateTask);
+router.patch(
+  '/:accountId/:projectId/tasks/:id',
+  [
+    body().custom(v => Object.keys(v || {}).length > 0).withMessage('Body cannot be empty'),
+    body('title').optional().isString(),
+    body('description').optional().isString(),
+    body('status').optional().isString(),
+    body('startDate').optional().isISO8601(),
+    body('endDate').optional().isISO8601(),
+    body('assignedTo').optional().isString(),
+    validate
+  ],
+  updateTask
+);
 router.delete('/:accountId/:projectId/tasks/:id', deleteTask);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add express-validator dependency
- create generic validation middleware
- validate user input in task routes
- validate user input in plans routes
- validate user input in model routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685619ed706c832396254608180e3f6d