### PR TITLE
Add API tests with Jest and Supertest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "nodemon app.js",
     "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +28,8 @@
   },
   "devDependencies": {
     "morgan": "^1.10.0",
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+
+jest.mock('../config/mongodb.js', () => jest.fn());
+jest.mock('axios');
+jest.mock('../libs/general/auth.libs', () => ({
+  GetAPSThreeLeggedToken: jest.fn(),
+  GetAPSToken: jest.fn(),
+}));
+
+const axios = require('axios');
+const authLibs = require('../libs/general/auth.libs');
+const app = require('../app');
+
+describe('API routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /general/userprofile', () => {
+    test('returns 200 with valid token', async () => {
+      axios.get.mockResolvedValueOnce({ data: { id: 'user' } });
+      const res = await request(app)
+        .get('/general/userprofile')
+        .set('Cookie', ['access_token=valid']);
+      expect(res.status).toBe(200);
+      expect(axios.get).toHaveBeenCalled();
+    });
+
+    test('returns 401 without token', async () => {
+      const res = await request(app).get('/general/userprofile');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /acc/accprojects', () => {
+    test('returns 200 with valid token', async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: { id: 'user' } }) // validateAutodeskToken
+        .mockResolvedValueOnce({ data: { data: [] } }); // GetProjects
+      const res = await request(app)
+        .get('/acc/accprojects')
+        .set('Cookie', ['access_token=valid']);
+      expect(res.status).toBe(200);
+      expect(axios.get).toHaveBeenCalled();
+    });
+
+    test('returns 401 without token', async () => {
+      const res = await request(app).get('/acc/accprojects');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /auth/three-legged', () => {
+    test('mocks login flow', async () => {
+      authLibs.GetAPSThreeLeggedToken.mockResolvedValue('tok');
+      const res = await request(app).get('/auth/three-legged?code=abc');
+      expect(res.status).toBe(302);
+      expect(res.headers['set-cookie'][0]).toContain('access_token=tok');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest configuration
- add Jest and Supertest dev dependencies
- add tests covering `/general/userprofile`, `/acc/accprojects` and `/auth/three-legged`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561a97a6148323b09730184da29bf6