### PR TITLE
Add IFC federated model to GLB endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ MONGODB_DATABASE_URL=mongodb://localhost:27017/tad
 
 GOOGLE_API_KEY=<Google generative AI API key>
 AUTODESK_BASE_URL=https://developer.api.autodesk.com
+BACKEND_BASE_URL=http://localhost:3000
 NODE_ENV=development           # production or development
 ```
 

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const helmet = require("helmet");
 const csurf = require('csurf');
+const path = require('path');
 
 
 require('./config/mongodb.js');
@@ -21,6 +22,9 @@ const app = express();
 app.disable('etag');
 app.disable("x-powered-by");
 app.set('trust proxy', 1);
+
+// Serve temporary GLB files
+app.use('/public/files', express.static(path.join(__dirname, 'public/files')));
 
 // Body parsers
 app.use(express.json({ limit: "250mb" }));

--- a/config/env.js
+++ b/config/env.js
@@ -12,6 +12,7 @@ const env = {
   ORDS_SCHEMA: process.env.ORDS_SCHEMA,
   MONGODB_DATABASE_URL: process.env.MONGODB_DATABASE_URL,
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  BACKEND_BASE_URL: process.env.BACKEND_BASE_URL,
   NODE_ENV: process.env.NODE_ENV || 'development',
   AUTODESK_BASE_URL: process.env.AUTODESK_BASE_URL
 };

--- a/controllers/data_management/ifc.data.management.controller.js
+++ b/controllers/data_management/ifc.data.management.controller.js
@@ -1,0 +1,114 @@
+const env = require("../../config/env.js");
+const axios = require("axios");
+const fs = require("fs");
+const path = require("path");
+const { GetFederatedModelFromFolders } = require("../../libs/general/folders.libs.js");
+const { convertIfcToGlb } = require("../../libs/conversion/ifc-to-glb.js");
+
+const MATCH_WORDS = ["FED-IFC", "FEDERADO-IFC", "FEDERATED-IFC"]; 
+
+function matchesFederatedIfc(displayName = "") {
+  const nameUpper = displayName.toUpperCase();
+  if (!nameUpper.endsWith(".IFC")) return false;
+  return MATCH_WORDS.some((w) => nameUpper.includes(w));
+}
+
+const GetIFCFederatedModel = async (req, res) => {
+  const token = req.cookies["access_token"];
+  const { projectId, accountId } = req.params;
+
+  if (!token) {
+    return res.status(401).json({
+      data: null,
+      error: "No token provided",
+      message: "Authorization token is required",
+    });
+  }
+
+  try {
+    const { data: topFolders } = await axios.get(
+      `${env.AUTODESK_BASE_URL}/project/v1/hubs/${accountId}/projects/${projectId}/topFolders`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!topFolders.data?.length) {
+      return res.status(404).json({
+        data: null,
+        error: "No top folders found",
+        message: "The project does not have any top folders",
+      });
+    }
+
+    const projectFolder = topFolders.data.find(
+      (f) =>
+        f.attributes.displayName === "Project Files" ||
+        f.attributes.displayName.toLowerCase() === "archivos de proyecto"
+    );
+    const rootFolderId = projectFolder ? projectFolder.id : topFolders.data[0].id;
+
+    const foundFile = await GetFederatedModelFromFolders({
+      token,
+      projectId,
+      folderId: rootFolderId,
+      filterFn: (item) => matchesFederatedIfc(item.attributes?.displayName),
+    });
+
+    if (!foundFile) {
+      return res.status(404).json({
+        data: null,
+        error: "File not found",
+        message: "No .ifc file containing FED-IFC in its name was found",
+      });
+    }
+
+    const { data: versions } = await axios.get(
+      `${env.AUTODESK_BASE_URL}/data/v1/projects/${projectId}/items/${foundFile.id}/versions`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+
+    if (!versions.data?.length) {
+      return res.status(404).json({
+        data: null,
+        error: "No versions found",
+        message: "No versions were found for the located file",
+      });
+    }
+    const latestVersion = versions.data[0];
+
+    const storageUrl = latestVersion.relationships.storage.meta.link.href;
+    const response = await axios.get(storageUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+      responseType: "stream",
+    });
+    const tmpIfcPath = path.join("/tmp", `ifc_${Date.now()}.ifc`);
+    const writer = fs.createWriteStream(tmpIfcPath);
+    await new Promise((resolve, reject) => {
+      response.data.pipe(writer);
+      writer.on("finish", resolve);
+      writer.on("error", reject);
+    });
+
+    const tmpGlbPath = path.join("/tmp", `ifc_${Date.now()}.glb`);
+    await convertIfcToGlb(tmpIfcPath, tmpGlbPath);
+
+    const glbUrl = `${env.BACKEND_BASE_URL}/public/files/${path.basename(tmpGlbPath)}`;
+
+    return res.status(200).json({
+      data: {
+        glbUrl,
+        displayName: foundFile.attributes.displayName,
+      },
+      error: null,
+      message: "Federated IFC model found, converted and ready for VR",
+    });
+  } catch (error) {
+    console.error("Error processing federated IFC model:", error.message || error);
+    res.status(500).json({
+      data: null,
+      error: error.message,
+      message: "Error accessing or converting the federated IFC model",
+    });
+  }
+};
+
+module.exports = { GetIFCFederatedModel };

--- a/libs/conversion/ifc-to-glb.js
+++ b/libs/conversion/ifc-to-glb.js
@@ -1,0 +1,12 @@
+const { IFCManager } = require('web-ifc');
+const fs = require('fs');
+
+async function convertIfcToGlb(ifcPath, glbPath) {
+  const manager = new IFCManager();
+  await manager.OpenModel(ifcPath);
+  const glbBuffer = await manager.SaveModelAsGLB();
+  fs.writeFileSync(glbPath, glbBuffer);
+  await manager.CloseModel();
+}
+
+module.exports = { convertIfcToGlb };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
     "mongoose": "^8.14.1",
-    "oracledb": "^6.8.0"
+    "oracledb": "^6.8.0",
+    "web-ifc": "^0.0.46"
   },
   "devDependencies": {
     "morgan": "^1.10.0",

--- a/resources/datamanagement/datamanagement.router.js
+++ b/resources/datamanagement/datamanagement.router.js
@@ -8,10 +8,12 @@ const { GetFileData } = require("./datamanagement.items.controller.js");
 const { GetFolderPermits } = require("./datamanagement.folder.permits.js");
 
 const { GetFileRevisionStatus } = require("./datamanagement.files.reviews.controller.js");
+const { GetIFCFederatedModel } = require("../../controllers/data_management/ifc.data.management.controller.js");
 
 const router = express.Router();
 
 router.get("/items/:accountId/:projectId/federatedmodel", GetFederatedModel);
+router.get("/items/:accountId/:projectId/federated-ifc", GetIFCFederatedModel);
 router.get("/folders/:accountId/:projectId/folder-structure", GetFoldersStructure);
 router.get("/folders/:accountId/:projectId/permissions", GetFolderPermits);
 


### PR DESCRIPTION
## Summary
- add endpoint controller to locate a federated IFC model, convert to GLB and return URL
- expose static `/public/files` for GLB serving
- include conversion helper using `web-ifc`
- extend router and environment config
- document BACKEND_BASE_URL in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68562e4626ac832384d1649b68697d47